### PR TITLE
fix(pool): deprecate job pool size

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ pool.NewBWorkerPool(concurrency int, opts ...OptionPool)
 - List available options:
 
 ```go
-// WithJobPoolSize set the size of the job pool size. If you're not using this option, the default job pool size is 1.
-func WithJobPoolSize(n int) OptionPool
-
 // WithStartupStagger set the worker pool to stagger the startup of workers with the calculated delay.
 //
 // For example, if you set 3 concurrencies and 1s delay, it will start worker 1 at 0ms, worker 2 at 500ms,

--- a/pool/option.go
+++ b/pool/option.go
@@ -10,6 +10,7 @@ type OptionPool interface {
 }
 
 // WithJobPoolSize set the size of the job pool size. If you're not using this option, the default job pool size is 1.
+// [DEPRECATED] pool size will automatically adjust with num of concurrency.
 func WithJobPoolSize(n int) OptionPool {
 	return &withJobPoolSize{n}
 }
@@ -17,10 +18,7 @@ func WithJobPoolSize(n int) OptionPool {
 type withJobPoolSize struct{ n int }
 
 func (w *withJobPoolSize) Apply(o *internal.OptionPool) {
-	if w.n <= 0 {
-		return
-	}
-	o.JobPoolSize = w.n
+	// [DEPRECATED]
 }
 
 // WithStartupStagger set the worker pool to stagger the startup of workers with the calculated delay.
@@ -29,6 +27,7 @@ func (w *withJobPoolSize) Apply(o *internal.OptionPool) {
 // and worker 3 at 1000ms.
 //
 // This option will work if you set more than 1 concurrency since the first worker will always start immediately. Delay formula:
+//
 //	delay = d / time.Duration(concurrency-1)
 func WithStartupStagger(d time.Duration) OptionPool {
 	return &withStartupStagger{d}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -53,7 +53,7 @@ func NewBWorkerPool(concurrency int, opts ...OptionPool) BWorkerPool {
 	if concurrency <= 0 {
 		concurrency = 1
 	}
-	o := &internal.OptionPool{}
+	o := &internal.OptionPool{JobPoolSize: concurrency}
 	for _, opt := range opts {
 		if opt == nil {
 			continue

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -241,40 +241,6 @@ func TestWorkerPool(t *testing.T) {
 			wantErr:     false,
 			wantErrsLen: 0,
 		},
-		{
-			name: "test not blocked with jobs pool size",
-			args: args{
-				concurrency: 1,
-				opts:        []OptionPool{WithJobPoolSize(2)},
-			},
-			jobs: func(bwp BWorkerPool) *int64 {
-				var ret int64
-				var mu = &sync.Mutex{}
-
-				start := time.Now()
-				bwp.DoSimple(func() { // Consumed by the worker (not blocking)
-					time.Sleep(time.Second)
-					ret++
-				})
-				bwp.DoSimple(func() { // Queued at pool (not blocking)
-					mu.Lock()
-					defer mu.Unlock()
-					ret++
-				})
-				bwp.DoSimple(func() { // Queued at pool (not blocking)
-					mu.Lock()
-					defer mu.Unlock()
-					ret++
-				})
-				// The total block time should 0
-				ts := time.Since(start)
-				assert.LessOrEqual(t, ts, time.Millisecond*100) // Add 0.1s as a threshold
-				return &ret
-			},
-			wantRet:     3,
-			wantErr:     false,
-			wantErrsLen: 0,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Job pool size option need to be deprecated because on some use-cases the pool can be overflowing that can cause your system out of memory. For better stability, I decided to deprecate this option.